### PR TITLE
Recipe restarts tomcat instead of start everytime

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -61,5 +61,5 @@ include_recipe 'tomcat-all::set_tomcat_home'
 
 # Enabling tomcat service and starting
 service 'tomcat' do
-  action [:enable, :start]
+  action [:enable, :restart]
 end


### PR DESCRIPTION
The recipe default tries to start Tomcat server even when it was already running, causing an error when Vagrant provision runs for the second time. I changed the action to be *restart* and it's working for me now.