### PR TITLE
bump ark to 0.9.0

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ description      'Installs/Configures tomcat'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          '0.3.1'
 
-depends 'ark', '~> 0.8.2'
+depends 'ark', '~> 0.9.0'
 depends 'java', '~> 1.22.0'
 depends 'apt', '~> 2.4.0'
 


### PR DESCRIPTION
Can we allow for v0.9.0 of `ark` to be installed, either via `>= 0.8.2` or `~ 0.9.0`? The changes from [0.8.2 to 0.9.0](https://github.com/burtlo/ark/compare/v0.8.2...v0.9.0) are only to add support for Windows, but unfortunately, I have some other cookbooks that rely on v0.9.0.

Thanks!
