### PR TITLE
Minor fixes for Tomcat and Java 8 support

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -6,8 +6,8 @@ description      'Installs/Configures tomcat'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          '0.3.1'
 
-depends 'ark', '~> 0.8.2'
-depends 'java', '~> 1.22.0'
+depends 'ark', '~> 0.9.0'
+depends 'java', '~> 1.31.0'
 depends 'apt', '~> 2.4.0'
 
 supports 'ubuntu', '= 12.04'

--- a/templates/default/server.conf.erb
+++ b/templates/default/server.conf.erb
@@ -1,7 +1,9 @@
 <?xml version='1.0' encoding='utf-8'?>
 <Server port="<%= node["tomcat-all"]["shutdown_port"] %>" shutdown="SHUTDOWN">
   <Listener className="org.apache.catalina.core.AprLifecycleListener" SSLEngine="on" />
+<% unless node['tomcat-all']['version'][0] == '8' %>
   <Listener className="org.apache.catalina.core.JasperListener" />
+<% end %>
   <Listener className="org.apache.catalina.core.JreMemoryLeakPreventionListener" />
   <Listener className="org.apache.catalina.mbeans.GlobalResourcesLifecycleListener" />
   <Listener className="org.apache.catalina.core.ThreadLocalLeakPreventionListener" />


### PR DESCRIPTION
To support Tomcat and Java 8 I needed to make two changes:
* Bump version dependencies for the new Java cookbook.
* Changed the server.conf.erb template to not render the JasperListener line for Tomcat 8. Support for this has been dropped.

With node attributes java.jdk_version = '8' and tomcat-all.version = '8.0.24' set this will result in an install with the latest versions.