### PR TITLE
Increment version to v0.3.2 reflect changes since v0.3.1

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'robertomoutinho@gmail.com'
 license          'All rights reserved'
 description      'Installs/Configures tomcat'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.3.1'
+version          '0.3.2'
 
 depends 'ark', '~> 0.9.0'
 depends 'java', '~> 1.31.0'


### PR DESCRIPTION
@robertomoutinho Can you please merge this pull request to increment the cookbook version? I want to use this cookbook but the v0.3.1 tag doesn't match what's in master. This PR increments the version. If you can also add a tag for this version, I would much appreciate, thanks!
